### PR TITLE
FIX-NODE-COMPATIBLE adding xmlhttprequest to replace browser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
         "babel-polyfill": "^6.22.0",
         "babel-preset-es2015": "^6.22.0",
         "babelify": "^7.3.0",
-        "browserify-versionify": "^1.0.6"
+        "browserify-versionify": "^1.0.6",
+        "xmlhttprequest": "^1.8.0"
     },
     "browserify": {
         "transform": [

--- a/src/ajax-promises.js
+++ b/src/ajax-promises.js
@@ -1,3 +1,5 @@
+var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
+
 function addHeaders(request, options) {
     const headers = options.headers || {};
     for(let header in headers) {


### PR DESCRIPTION
Fix for https://github.com/kribblo/ajax-promises/issues/2.